### PR TITLE
Remove dleyna support

### DIFF
--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -13,7 +13,6 @@
     "--talk-name=org.gnome.OnlineAccounts",
     "--own-name=org.mpris.MediaPlayer2.GnomeMusic",
     "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
-    "--talk-name=com.intel.dleyna-server",
     "--talk-name=org.gtk.vfs",
     "--talk-name=org.gtk.vfs.*",
     "--socket=pulseaudio",
@@ -137,7 +136,7 @@
       "name": "grilo-plugins",
       "buildsystem": "meson",
       "config-opts": [
-        "-Denable-dleyna=yes",
+        "-Denable-dleyna=no",
         "-Denable-tracker=yes",
         "-Denable-bookmarks=no",
         "-Denable-filesystem=no",


### PR DESCRIPTION
GNOME Music does not use it. See:
https://gitlab.gnome.org/GNOME/gnome-music/commit/e05375fa2e75ab78e851836a94141e5bbbe5b264

Closes: https://github.com/flathub/org.gnome.Music/issues/13