### PR TITLE
Update to 3.38

### DIFF
--- a/gst-python.patch
+++ b/gst-python.patch
@@ -1,0 +1,32 @@
+diff --git a/meson.build b/meson.build
+index 744b7ce..97f48ab 100644
+--- a/meson.build
++++ b/meson.build
+@@ -13,6 +13,8 @@ api_version = '@0@.0'.format(gst_version_major)
+
+ add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
++
++
+ gst_req = '>= @0@.@1@.0'.format(gst_version_major, gst_version_minor)
+
+ gst_dep = dependency('gstreamer-1.0', version : gst_req,
+@@ -24,7 +26,17 @@ pygobject_dep = dependency('pygobject-3.0', fallback: ['pygobject', 'pygobject_d
+
+ pymod = import('python')
+ python = pymod.find_installation(get_option('python'))
+-python_dep = python.dependency(required : true)
++pythonver = python.language_version()
++if pythonver.version_compare('<3.0')
++  error('Python2 is not supported anymore, please port your code to python3 (@0@ specified)'.format(python.language_version()))
++endif
++
++# Workaround for https://github.com/mesonbuild/meson/issues/5629
++# https://gitlab.freedesktop.org/gstreamer/gst-python/issues/28
++python_dep = dependency('python-@0@-embed'.format(pythonver), version: '>=3', required: false)
++if not python_dep.found()
++  python_dep = python.dependency(required : true)
++endif
+
+ python_abi_flags = python.get_variable('ABIFLAGS', '')
+ pylib_loc = get_option('libpython-dir')

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -1,24 +1,25 @@
 {
   "app-id": "org.gnome.Music",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.36",
+  "runtime-version": "3.38",
   "sdk": "org.gnome.Sdk",
   "command": "gnome-music",
   "finish-args": [
     "--share=ipc", "--socket=fallback-x11",
     "--share=network",
     "--socket=wayland",
-    "--talk-name=org.freedesktop.Tracker1",
-    "--env=TRACKER_SPARQL_BACKEND=bus",
     "--talk-name=org.gnome.OnlineAccounts",
+    "--talk-name=org.gnome.ControlCenter",
     "--own-name=org.mpris.MediaPlayer2.GnomeMusic",
+    "--talk-name=org.freedesktop.Tracker3.Writeback",
     "--talk-name=org.gnome.SettingsDaemon.MediaKeys",
     "--talk-name=org.gtk.vfs",
     "--talk-name=org.gtk.vfs.*",
     "--socket=pulseaudio",
     "--filesystem=xdg-music",
     "--system-talk-name=org.freedesktop.login1",
-    "--metadata=X-DConf=migrate-path=/org/gnome/Music/"
+    "--metadata=X-DConf=migrate-path=/org/gnome/Music/",
+    "--add-policy=Tracker3.dbus:org.freedesktop.Tracker3.Miner.Files=tracker:Audio"
   ],
   "cleanup": [
     "/include",
@@ -67,32 +68,27 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/libdazzle/3.36/libdazzle-3.36.0.tar.xz",
-          "sha256": "82b31bbf550fc62970c78bf7f9d55e5fae5b8ea13b24fe2d13c8c6039409d958"
+          "url": "https://download.gnome.org/sources/libdazzle/3.38/libdazzle-3.38.0.tar.xz",
+          "sha256": "e18af28217943bcec106585298a91ec3da48aa3ad62fd0992f23f0c70cd1678f"
         }
       ]
     },
     {
-      "name": "tracker",
+      "name": "tracker-miners",
       "buildsystem": "meson",
-      "cleanup": [
-        "/bin",
-        "/etc",
-        "/libexec"
-      ],
-      "config-opts": [
-        "-Ddocs=false",
-        "-Dfunctional_tests=false",
-        "-Dnetwork_manager=disabled",
-        "-Dstemmer=disabled",
-        "-Dunicode_support=icu",
-        "-Dbash_completion=no"
-      ],
+      "config-opts": [ "-Ddefault_index_single_directories=",
+                       "-Ddefault_index_recursive_directories=&MUSIC",
+                       "-Ddomain_prefix=org.gnome.Music",
+                       "-Dman=false",
+                       "-Dminer_fs=true",
+                       "-Dminer_fs_cache_location=$XDG_CACHE_HOME/gnome-music/miner/files",
+                       "-Dminer_rss=false",
+                       "-Dsystemd_user_services=false"],
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/tracker/2.3/tracker-2.3.4.tar.xz",
-          "sha256": "577952244ab977c78b0b88e2f63c4197eaba16e4d66bff692b7f58993e06516d"
+          "url": "https://download.gnome.org/sources/tracker-miners/3.0/tracker-miners-3.0.0.tar.xz",
+          "sha256": "bb481a7c23c5def4f215627a0630fbe9d1c64f3319825859d7a73645738f4042"
         }
       ]
     },
@@ -137,8 +133,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/grilo/0.3/grilo-0.3.12.tar.xz",
-          "sha256": "dbfbd6082103288592af97568180b9cc81a336a274ed5160412f87675ec11a71"
+          "url": "https://download.gnome.org/sources/grilo/0.3/grilo-0.3.13.tar.xz",
+          "sha256": "d14837f22341943ed8a189d9f0827a17016b802d18d0ed080e1413de0fdc927b"
         }
       ],
       "cleanup": [
@@ -151,7 +147,8 @@
       "buildsystem": "meson",
       "config-opts": [
         "-Denable-dleyna=no",
-        "-Denable-tracker=yes",
+        "-Denable-tracker=no",
+        "-Denable-tracker3=yes",
         "-Denable-bookmarks=no",
         "-Denable-filesystem=no",
         "-Denable-freebox=no",
@@ -169,8 +166,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/grilo-plugins/0.3/grilo-plugins-0.3.11.tar.xz",
-          "sha256": "dde2e605b1994341c6bf012493e056b406b08571834dea3b3c671d5b8b1dcd73"
+          "url": "https://download.gnome.org/sources/grilo-plugins/0.3/grilo-plugins-0.3.12.tar.xz",
+          "sha256": "c6b6df086a164d65c206d70139ce80591f8feca3545612e45b823fb4fe4b2577"
         }
       ],
       "cleanup": [
@@ -183,8 +180,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.gnome.org/sources/gnome-music/3.36/gnome-music-3.36.4.1.tar.xz",
-          "sha256": "509e116f8b49aa8efe51d51010ea788255f6ef18d3d0cc8d597821e2f893b77d"
+          "url": "https://download.gnome.org/sources/gnome-music/3.38/gnome-music-3.38.0.tar.xz",
+          "sha256": "370aa97ee4610d11b4b8f691e5c9ce30fa55665870bf6d5f2319658bdfacd705"
         }
       ]
     }

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -56,6 +56,10 @@
           "type": "git",
           "branch": "1.16.2",
           "url": "https://gitlab.freedesktop.org/gstreamer/gst-python.git"
+        },
+        {
+          "type": "patch",
+          "path": "gst-python.patch"
         }
       ]
     },

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -5,7 +5,7 @@
   "sdk": "org.gnome.Sdk",
   "command": "gnome-music",
   "finish-args": [
-    "--share=ipc", "--socket=x11",
+    "--share=ipc", "--socket=fallback-x11",
     "--share=network",
     "--socket=wayland",
     "--talk-name=org.freedesktop.Tracker1",


### PR DESCRIPTION
- Update gnome runtime
- Added gst-python patch
- Removed tracker, use portal instead
- Added tracker-miners following upstream manifest
- Use fallback-x11 socket, following upstream manifest