### PR TITLE
Fix x-checker-data and update to 48.0

### DIFF
--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.Music",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-music",
     "finish-args": [

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libmediaart/1.9/libmediaart-1.9.6.tar.xz",
-                    "sha256": "c3bc5025d7db380587f9c8eb800c611f6b5a16d6b4b78fcff93f62876a677f17",
+                    "url": "https://download.gnome.org/sources/libmediaart/1.9/libmediaart-1.9.7.tar.xz",
+                    "sha256": "2b43dd9f54f0d8d0b89e2addb83341ab06d7b98cb1b2e704383584af9c560f6b",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libmediaart"
@@ -82,8 +82,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/localsearch/3.8/localsearch-3.8.1.tar.xz",
-                    "sha256": "a7b24a4f07805df7543a4dd023684fcde5ee699ca00eb5b09123a049d3aeccd8",
+                    "url": "https://download.gnome.org/sources/localsearch/3.9/localsearch-3.9.0.tar.xz",
+                    "sha256": "d42f408dc3fb28fe54f5a9abbf5f1decf5818db9c2e9ec51c09464bdfd0c14b9",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "localsearch"
@@ -171,8 +171,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-music/47/gnome-music-47.1.tar.xz",
-                    "sha256": "666f175f560a1ad9cbab61ea0f30393ca2fed2946ba46e5c00eaea117dbc70d0",
+                    "url": "https://download.gnome.org/sources/gnome-music/48/gnome-music-48.0.tar.xz",
+                    "sha256": "8cdaacd05262b63bb1608a25acad516e892c332232357cb9b7f68f2cfb86d66e",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gnome-music",

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -41,7 +41,6 @@
                     "sha256": "c3bc5025d7db380587f9c8eb800c611f6b5a16d6b4b78fcff93f62876a677f17",
                     "x-checker-data": {
                         "type": "gnome",
-                        "stable-only": false,
                         "name": "libmediaart"
                     }
                 }
@@ -87,7 +86,6 @@
                     "sha256": "a7b24a4f07805df7543a4dd023684fcde5ee699ca00eb5b09123a049d3aeccd8",
                     "x-checker-data": {
                         "type": "gnome",
-                        "stable-only": false,
                         "name": "localsearch"
                     }
                 }
@@ -122,7 +120,6 @@
                     "sha256": "884580e8c5ece280df23aa63ff5234b7d48988a404df7d6bfccd1e77b473bd96",
                     "x-checker-data": {
                         "type": "gnome",
-                        "stable-only": false,
                         "name": "grilo"
                     }
                 }
@@ -160,7 +157,6 @@
                     "sha256": "fe6f4dbe586c6b8ba2406394e202f22d009d642a96eb3a54f32f6a21d084cdcb",
                     "x-checker-data": {
                         "type": "gnome",
-                        "stable-only": false,
                         "name": "grilo-plugins"
                     }
                 }

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -76,7 +76,6 @@
                 "-Dman=false",
                 "-Dminer_fs=true",
                 "-Dminer_fs_cache_location=$XDG_CACHE_HOME/gnome-music/miner/files",
-                "-Dminer_rss=false",
                 "-Dsystemd_user_services=false"
             ],
             "sources": [


### PR DESCRIPTION
If any module is using the 'odd minor version means unstable' versioning scheme, it should use

```json
"version-scheme": "odd-minor-is-unstable"
```